### PR TITLE
feat: add zoom / reset view controls and ability to pan

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -372,6 +372,53 @@ li#item-remaining::before {
     padding: 20px;
 }
 
+#chart-zoom-controls {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 2;
+}
+
+#chart-zoom-controls button {
+    width: 36px;
+    height: 36px;
+    border-radius: 6px;
+    border: 1px solid #ddd;
+    background: #fff;
+    color: #443F3F;
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    transition: transform 120ms ease, border-color 120ms ease;
+}
+
+#chart-zoom-controls svg {
+    width: 18px;
+    height: 18px;
+    display: block;
+    margin: 0 auto;
+}
+
+#zoom-reset {
+    width: 36px;
+    height: 36px;
+    padding: 0;
+}
+
+#chart-zoom-controls button:hover {
+    border-color: #CF3F02;
+    transform: translateY(-1px);
+}
+
+#chart-zoom-controls button:active {
+    transform: translateY(0);
+}
+
 #chart-container canvas {
     display: block;
     margin: 0;

--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -59,6 +59,17 @@
 
             <!-- The visual will be drawn here -->
             <div id="chart-container">
+                <div id="chart-zoom-controls" aria-label="Zoom controls">
+                    <button id="zoom-in" type="button" aria-label="Zoom in">+</button>
+                    <button id="zoom-out" type="button" aria-label="Zoom out">−</button>
+                    <button id="zoom-reset" type="button" aria-label="Reset zoom">
+                        <svg class="zoom-reset-icon" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+                            <circle cx="12" cy="12" r="7" fill="none" stroke="currentColor" stroke-width="2"/>
+                            <circle cx="12" cy="12" r="1.5" fill="currentColor"/>
+                            <path d="M12 3v3M12 18v3M3 12h3M18 12h3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                        </svg>
+                    </button>
+                </div>
             </div>
 
         </div>


### PR DESCRIPTION
While exploring the repos in the visualization graph, I noticed that some basic navigation controls would be helpful. This change adds a small set of view controls to make inspection easier:

- Add zoom in / zoom out / reset view controls
- Enable drag-to-pan interaction


https://github.com/user-attachments/assets/dc3567ae-df00-4241-990a-7ac7ff398ccb

