### PR TITLE
fix org reference for central node

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 title = "The Development Seed Contributor Network"
 author = "Pete Gadomski"
 description = "An interactive visualization of contributors to Development Seed code and their connections to other repositories"
-central_repository = "DevSeed Team"
+central_repository = "developmentseed/DevSeed Team"
 repositories = [
     "developmentseed/titiler",
     "developmentseed/lonboard",

--- a/python/templates/index.html.jinja
+++ b/python/templates/index.html.jinja
@@ -51,7 +51,7 @@
             <div id="chart-introduction">
                 <div id="chart-title">
                     <h1>The Contributor Network of</h1>
-                    <h1><span id="title-repo-name" class="central-repo">{{ central_repository }}</span></h1>
+                    <h1><span id="title-repo-name" class="central-repo">{{ central_repository.split('/')[-1] }}</span></h1>
                     <p id="last-commit-date"></p>
                 </div>
                  <div id="chart-intro-text">


### PR DESCRIPTION
### Root cause

config.toml had central_repository = "DevSeed Team" (no org prefix), but the CSV data on disk has developmentseed/DevSeed Team (with org prefix). When the Jinja template passed "DevSeed Team" as REPO_CENTRAL to the visualization, prepareData created nodes from the CSV with id: "developmentseed/DevSeed Team", so the lookup d.id === "DevSeed Team" failed.

This likely happened during the refactoring, probably because I removed the center node visualization. I made a followup ticket to fully remove #40 
The config value was shortened to just the display name, but the CSV (which was generated earlier with the full owner/repo format) wasn't regenerated.

Two changes made:

1. config.toml — restored the full owner/repo format: central_repository = "developmentseed/DevSeed Team". This matches the CSV data and the convention used by every other repository in the config.
2. python/templates/index.html.jinja line 54 — changed the title display from {{ central_repository }} to {{ central_repository.split('/')[-1] }} so the heading still renders as "DevSeed Team" rather than the full path.