### PR TITLE
Add ECMWF repos to config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -72,6 +72,8 @@ repositories = [
     "developmentseed/pixelverse",
     "NASA-IMPACT/veda-odd",
     "Disasters-Learning-Portal/veda-disasters",
+    "ecmwf/qubed",
+    "ecmwf/polytope-client"
 ]
 
 # Friends and alumni - commented out but preserved for future use


### PR DESCRIPTION
Our main repos are not public **yet**, but this way at least the org will show up on the list.