### PR TITLE
Sponsored/community backend: community contributors during build

### DIFF
--- a/python/contributor_network/cli.py
+++ b/python/contributor_network/cli.py
@@ -313,6 +313,15 @@ def _fetch_data(
         click.echo("  Updating links...")
         client.update_links(repo, contributors, core_usernames=core_usernames)
 
+        if all_contributors:
+            click.echo("  Discovering community contributors...")
+            community = client.discover_community_contributors(
+                repo, set(contributors.keys())
+            )
+            if community:
+                click.echo(f"  Found {len(community)} community contributors")
+                client.update_community_links(repo, community)
+
         if fetch_forking_orgs:
             client.update_repository_forking_orgs(repo)
 


### PR DESCRIPTION
## Summary

When `--all-contributors` is passed to build, discovers community contributors for each repo and creates link data for them.

## Value

Enables the backend data pipeline for showing community contributors alongside core team in the visualization.