### PR TITLE
Feat/commit ratio filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,17 @@
                     </select>
                 </div>
 
+                <div class="filter-group">
+                    <div class="filter-label" id="org-commit-ratio-label">Commit Ratio</div>
+                    <select id="org-commit-ratio-select">
+                        <option value="">Any</option>
+                        <option value="0.25">25%+</option>
+                        <option value="0.50">50%+</option>
+                        <option value="0.75">75%+</option>
+                        <option value="0.90">90%+</option>
+                    </select>
+                </div>
+
                 <p id="filter-stats"></p>
             </div>
         </div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -446,7 +446,7 @@ li#item-remaining::before {
 
 #filter-header {
     display: grid;
-    grid-template-columns: minmax(180px, 1fr) auto auto 1fr;
+    grid-template-columns: 2fr 1fr 1fr 1fr 3fr;
     align-items: end;
     gap: 24px;
 }
@@ -467,7 +467,8 @@ li#item-remaining::before {
 }
 
 #stars-select,
-#forks-select {
+#forks-select,
+#org-commit-ratio-select {
     padding: 8px 32px 8px 12px;
     font-size: 14px;
     border: 1.5px solid #ddd;
@@ -486,12 +487,14 @@ li#item-remaining::before {
 }
 
 #stars-select:hover,
-#forks-select:hover {
+#forks-select:hover,
+#org-commit-ratio-select:hover {
     border-color: var(--color-repo-main);
 }
 
 #stars-select:focus,
-#forks-select:focus {
+#forks-select:focus,
+#org-commit-ratio-select:focus {
     outline: none;
     border-color: var(--color-repo-main);
     box-shadow: 0 0 0 2px rgba(207, 63, 2, 0.1);
@@ -835,7 +838,8 @@ li#item-remaining::before {
     }
 
     #stars-select,
-    #forks-select {
+    #forks-select,
+    #org-commit-ratio-select {
         width: 100%;
     }
 

--- a/src/__tests__/classify.test.ts
+++ b/src/__tests__/classify.test.ts
@@ -58,7 +58,7 @@ function makeLink(sourceId: string, targetId: string, repo: string): LinkData {
 }
 
 function noFilters(): FilterState {
-  return { organizations: [], starsMin: null, forksMin: null };
+  return { organizations: [], starsMin: null, forksMin: null, orgCommitRatioMin: null };
 }
 
 describe('classifyByFilters', () => {
@@ -84,7 +84,7 @@ describe('classifyByFilters', () => {
   });
 
   it('filters by organization', () => {
-    classifyByFilters(nodes, links, { organizations: ['alpha'], starsMin: null, forksMin: null });
+    classifyByFilters(nodes, links, { organizations: ['alpha'], starsMin: null, forksMin: null, orgCommitRatioMin: null });
 
     expect(repoA.filteredOut).toBe(false);
     expect(repoC.filteredOut).toBe(false);
@@ -98,7 +98,7 @@ describe('classifyByFilters', () => {
   });
 
   it('filters by minimum stars', () => {
-    classifyByFilters(nodes, links, { organizations: [], starsMin: 50, forksMin: null });
+    classifyByFilters(nodes, links, { organizations: [], starsMin: 50, forksMin: null, orgCommitRatioMin: null });
 
     expect(repoA.filteredOut).toBe(false);
     expect(repoB.filteredOut).toBe(false);
@@ -109,7 +109,7 @@ describe('classifyByFilters', () => {
   });
 
   it('filters by minimum forks', () => {
-    classifyByFilters(nodes, links, { organizations: [], starsMin: null, forksMin: 10 });
+    classifyByFilters(nodes, links, { organizations: [], starsMin: null, forksMin: 10, orgCommitRatioMin: null });
 
     expect(repoA.filteredOut).toBe(false);
     expect(repoB.filteredOut).toBe(true);
@@ -117,7 +117,7 @@ describe('classifyByFilters', () => {
   });
 
   it('applies combined filters (intersection)', () => {
-    classifyByFilters(nodes, links, { organizations: ['alpha'], starsMin: 50, forksMin: null });
+    classifyByFilters(nodes, links, { organizations: ['alpha'], starsMin: 50, forksMin: null, orgCommitRatioMin: null });
 
     expect(repoA.filteredOut).toBe(false);
     expect(repoB.filteredOut).toBe(true);
@@ -129,7 +129,7 @@ describe('classifyByFilters', () => {
   });
 
   it('marks links based on endpoint visibility', () => {
-    classifyByFilters(nodes, links, { organizations: ['alpha'], starsMin: null, forksMin: null });
+    classifyByFilters(nodes, links, { organizations: ['alpha'], starsMin: null, forksMin: null, orgCommitRatioMin: null });
 
     // Alice → repoA: both visible
     expect(links[0].filteredOut).toBe(false);
@@ -156,7 +156,7 @@ describe('classifyByFilters', () => {
     const testNodes = [repo, owner, contrib];
     const testLinks = [ownerRepoLink, contribOwnerLink];
 
-    classifyByFilters(testNodes, testLinks, { organizations: ['alpha'], starsMin: null, forksMin: null });
+    classifyByFilters(testNodes, testLinks, { organizations: ['alpha'], starsMin: null, forksMin: null, orgCommitRatioMin: null });
 
     expect(repo.filteredOut).toBe(false);
     expect(owner.filteredOut).toBe(false);

--- a/src/__tests__/filter.test.ts
+++ b/src/__tests__/filter.test.ts
@@ -5,6 +5,7 @@ import {
   filterReposByOrganization,
   filterReposByStars,
   filterReposByForks,
+  filterReposByOrgCommitRatio,
   filterLinksByRepos,
   filterLinksByContributors,
   filterContributorsByLinks,
@@ -14,11 +15,11 @@ import {
 import type { RepoData, ContributorData, LinkData } from '../types';
 
 const sampleRepos = [
-  { repo: 'developmentseed/titiler', stars: 100, repo_stars: '1036', repo_forks: '216' },
-  { repo: 'developmentseed/rio-cogeo', stars: 50, repo_stars: '50', repo_forks: '10' },
-  { repo: 'stac-utils/stac-fastapi', stars: 200, repo_stars: '304', repo_forks: '116' },
-  { repo: 'radiantearth/stac-spec', stars: 300, repo_stars: '875', repo_forks: '188' },
-  { repo: 'DevSeed Team', stars: 0, repo_stars: '0', repo_forks: '0' }
+  { repo: 'developmentseed/titiler', stars: 100, repo_stars: '1036', repo_forks: '216', totalCommits: 200, orgCommits: 180 },
+  { repo: 'developmentseed/rio-cogeo', stars: 50, repo_stars: '50', repo_forks: '10', totalCommits: 100, orgCommits: 30 },
+  { repo: 'stac-utils/stac-fastapi', stars: 200, repo_stars: '304', repo_forks: '116', totalCommits: 500, orgCommits: 100 },
+  { repo: 'radiantearth/stac-spec', stars: 300, repo_stars: '875', repo_forks: '188', totalCommits: 1000, orgCommits: 50 },
+  { repo: 'DevSeed Team', stars: 0, repo_stars: '0', repo_forks: '0', totalCommits: 0, orgCommits: 0 }
 ] as unknown as RepoData[];
 
 const sampleContributors = [
@@ -194,6 +195,36 @@ describe('filterReposByForks', () => {
   });
 });
 
+describe('filterReposByOrgCommitRatio', () => {
+  it('should filter repos below the commit ratio threshold', () => {
+    const result = filterReposByOrgCommitRatio(sampleRepos, 0.25);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r: RepoData) => r.repo)).toEqual([
+      'developmentseed/titiler',
+      'developmentseed/rio-cogeo',
+    ]);
+  });
+
+  it('should hide repos with zero total commits', () => {
+    const result = filterReposByOrgCommitRatio(sampleRepos, 0.01);
+
+    expect(result.some((r: RepoData) => r.repo === 'DevSeed Team')).toBe(false);
+  });
+
+  it('should return no repos when threshold is 1.0 and none are 100%', () => {
+    const result = filterReposByOrgCommitRatio(sampleRepos, 1.0);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should include repos exactly at the threshold', () => {
+    const result = filterReposByOrgCommitRatio(sampleRepos, 0.90);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].repo).toBe('developmentseed/titiler');
+  });
+});
+
 interface OriginalData {
   contributors: ContributorData[] | null;
   repos: RepoData[] | null;
@@ -212,7 +243,7 @@ describe('applyFilters', () => {
   });
 
   it('should return all data when no filters active', () => {
-    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: [], starsMin: null, forksMin: null });
+    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: [], starsMin: null, forksMin: null, orgCommitRatioMin: null });
 
     expect(result.repos).toHaveLength(sampleRepos.length);
     expect(result.contributors).toHaveLength(sampleContributors.length);
@@ -220,7 +251,7 @@ describe('applyFilters', () => {
   });
 
   it('should filter by organization correctly', () => {
-    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: ['developmentseed'], starsMin: null, forksMin: null });
+    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: ['developmentseed'], starsMin: null, forksMin: null, orgCommitRatioMin: null });
 
     expect(result.repos).toHaveLength(2);
 
@@ -233,7 +264,7 @@ describe('applyFilters', () => {
   it('should include central repo when specified', () => {
     const result = applyFilters(
       originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] },
-      { organizations: ['stac-utils'], starsMin: null, forksMin: null },
+      { organizations: ['stac-utils'], starsMin: null, forksMin: null, orgCommitRatioMin: null },
       { centralRepo: 'DevSeed Team' }
     );
 
@@ -241,7 +272,7 @@ describe('applyFilters', () => {
   });
 
   it('should return deep clones to prevent mutation', () => {
-    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: [], starsMin: null, forksMin: null });
+    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: [], starsMin: null, forksMin: null, orgCommitRatioMin: null });
 
     (result.repos[0] as RepoData & { stars: number }).stars = 999;
     (result.contributors[0] as ContributorData & { commits: number }).commits = 999;
@@ -255,7 +286,7 @@ describe('applyFilters', () => {
   it('should handle empty original data gracefully', () => {
     const result = applyFilters(
       { contributors: null, repos: null, links: null } as unknown as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] },
-      { organizations: [], starsMin: null, forksMin: null }
+      { organizations: [], starsMin: null, forksMin: null, orgCommitRatioMin: null }
     );
 
     expect(result.contributors).toEqual([]);
@@ -264,14 +295,14 @@ describe('applyFilters', () => {
   });
 
   it('should filter by minimum stars', () => {
-    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: [], starsMin: 500, forksMin: null });
+    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: [], starsMin: 500, forksMin: null, orgCommitRatioMin: null });
 
     expect(result.repos.length).toBeLessThan(sampleRepos.length);
     expect(result.repos.every((r: RepoData) => +(r.repo_stars ?? 0) >= 500)).toBe(true);
   });
 
   it('should filter by minimum forks', () => {
-    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: [], starsMin: null, forksMin: 100 });
+    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: [], starsMin: null, forksMin: 100, orgCommitRatioMin: null });
 
     expect(result.repos).toHaveLength(3);
     expect(result.repos.every((r: RepoData) => +(r.repo_forks ?? 0) >= 100)).toBe(true);
@@ -281,7 +312,8 @@ describe('applyFilters', () => {
     const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, {
       organizations: ['developmentseed'],
       starsMin: 100,
-      forksMin: null
+      forksMin: null,
+      orgCommitRatioMin: null,
     });
 
     expect(result.repos).toHaveLength(1);
@@ -289,7 +321,7 @@ describe('applyFilters', () => {
   });
 
   it('should correctly chain filters (repos -> links -> contributors -> links)', () => {
-    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: ['radiantearth'], starsMin: null, forksMin: null });
+    const result = applyFilters(originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] }, { organizations: ['radiantearth'], starsMin: null, forksMin: null, orgCommitRatioMin: null });
 
     expect(result.repos).toHaveLength(1);
     expect(result.repos[0].repo).toBe('radiantearth/stac-spec');
@@ -299,12 +331,24 @@ describe('applyFilters', () => {
 
     expect(result.links).toHaveLength(2);
   });
+
+  it('should filter by minimum org commit ratio', () => {
+    const result = applyFilters(
+      originalData as { contributors: ContributorData[]; repos: RepoData[]; links: LinkData[] },
+      { organizations: [], starsMin: null, forksMin: null, orgCommitRatioMin: 0.25 }
+    );
+
+    expect(result.repos.every((r: RepoData) => {
+      const total = r.totalCommits ?? 0;
+      return total > 0 && (r.orgCommits ?? 0) / total >= 0.25;
+    })).toBe(true);
+  });
 });
 
 describe('createFilterManager', () => {
   it('should start with empty filters', () => {
     const manager = createFilterManager();
-    expect(manager.getFilters()).toEqual({ organizations: [], starsMin: null, forksMin: null });
+    expect(manager.getFilters()).toEqual({ organizations: [], starsMin: null, forksMin: null, orgCommitRatioMin: null });
   });
 
   it('should add organization when setOrganization called with true', () => {
@@ -403,7 +447,8 @@ describe('createFilterManager', () => {
     expect(manager.getFilters()).toEqual({
       organizations: [],
       starsMin: null,
-      forksMin: null
+      forksMin: null,
+      orgCommitRatioMin: null,
     });
     expect(manager.hasActiveFilters()).toBe(false);
   });
@@ -425,5 +470,13 @@ describe('createFilterManager', () => {
 
     const filters = manager.getFilters();
     expect((filters as unknown as Record<string, unknown>)['invalidMetric']).toBeUndefined();
+  });
+
+  it('should set orgCommitRatioMin metric filter', () => {
+    const manager = createFilterManager();
+    manager.setMetricFilter('orgCommitRatioMin', 0.5);
+
+    expect(manager.getFilters().orgCommitRatioMin).toBe(0.5);
+    expect(manager.hasActiveFilters()).toBe(true);
   });
 });

--- a/src/data/classify.ts
+++ b/src/data/classify.ts
@@ -34,6 +34,10 @@ export function classifyByFilters(
     if (filterState.forksMin !== null) {
       visible = visible && (repo.forks ?? 0) >= filterState.forksMin;
     }
+    if (filterState.orgCommitRatioMin !== null) {
+      const total = repo.totalCommits ?? 0;
+      visible = visible && total > 0 && (repo.orgCommits ?? 0) / total >= filterState.orgCommitRatioMin;
+    }
 
     node.filteredOut = !visible;
     if (visible) visibleRepoIds.add(node.id);

--- a/src/data/filter.ts
+++ b/src/data/filter.ts
@@ -93,6 +93,25 @@ export function filterReposByForks(
 }
 
 /**
+ * Filter repositories by minimum percentage of commits from org contributors.
+ *
+ * @param repos - Array of repository objects
+ * @param minRatio - Minimum ratio (0-1) of org commits to total commits
+ * @returns Filtered repositories
+ */
+export function filterReposByOrgCommitRatio(
+  repos: RepoData[],
+  minRatio: number,
+): RepoData[] {
+  return repos.filter((repo) => {
+    const total = repo.totalCommits ?? 0;
+    if (total === 0) return false;
+    const orgRatio = (repo.orgCommits ?? 0) / total;
+    return orgRatio >= minRatio;
+  });
+}
+
+/**
  * Filter links to only those pointing to visible repositories.
  *
  * @param links - Array of link objects with 'repo' property
@@ -189,6 +208,9 @@ export function applyFilters(
   if (activeFilters.forksMin != null) {
     visibleRepos = filterReposByForks(visibleRepos, activeFilters.forksMin);
   }
+  if (activeFilters.orgCommitRatioMin != null) {
+    visibleRepos = filterReposByOrgCommitRatio(visibleRepos, activeFilters.orgCommitRatioMin);
+  }
 
   const visibleRepoNames = new Set(visibleRepos.map((r) => r.repo));
 
@@ -234,7 +256,7 @@ export function applyFilters(
 interface FilterManager {
   getFilters(): FilterState;
   setOrganization(org: string, active: boolean): void;
-  setMetricFilter(metric: "starsMin" | "forksMin", value: number | null): void;
+  setMetricFilter(metric: "starsMin" | "forksMin" | "orgCommitRatioMin", value: number | null): void;
   clearOrganizations(): void;
   clearAll(): void;
   hasActiveFilters(): boolean;
@@ -254,6 +276,7 @@ export function createFilterManager(
     organizations: [],
     starsMin: null,
     forksMin: null,
+    orgCommitRatioMin: null,
   };
 
   return {
@@ -278,10 +301,10 @@ export function createFilterManager(
     },
 
     setMetricFilter(
-      metric: "starsMin" | "forksMin",
+      metric: "starsMin" | "forksMin" | "orgCommitRatioMin",
       value: number | null,
     ): void {
-      if (metric === "starsMin" || metric === "forksMin") {
+      if (metric === "starsMin" || metric === "forksMin" || metric === "orgCommitRatioMin") {
         activeFilters[metric] = value;
       }
 
@@ -302,6 +325,7 @@ export function createFilterManager(
       activeFilters.organizations = [];
       activeFilters.starsMin = null;
       activeFilters.forksMin = null;
+      activeFilters.orgCommitRatioMin = null;
 
       if (onChange) {
         onChange(this.getFilters());
@@ -312,7 +336,8 @@ export function createFilterManager(
       return (
         activeFilters.organizations.length > 0 ||
         activeFilters.starsMin !== null ||
-        activeFilters.forksMin !== null
+        activeFilters.forksMin !== null ||
+        activeFilters.orgCommitRatioMin !== null
       );
     },
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,6 +129,18 @@ document.fonts.ready.then(() => {
         updateFilterStats();
       });
 
+      const commitRatioSelect = document.getElementById(
+        "org-commit-ratio-select"
+      ) as HTMLSelectElement;
+      const commitRatioLabel = document.getElementById("org-commit-ratio-label")!;
+      commitRatioLabel.textContent = `${orgNickname} Commit Ratio`;
+      commitRatioSelect.addEventListener("change", function () {
+        const value =
+          this.value === "" ? null : parseFloat(this.value);
+        contributorNetworkVisual.setRepoFilter("orgCommitRatioMin", value);
+        updateFilterStats();
+      });
+
       function updateFilterStats(): void {
         const statsElement = document.getElementById("filter-stats")!;
         const parts: string[] = [];
@@ -147,6 +159,9 @@ document.fonts.ready.then(() => {
         if (forksSelect.value !== "") {
           parts.push(`forks: ${forksSelect.value}+`);
         }
+        if (commitRatioSelect.value !== "") {
+          parts.push(`${orgNickname} commits: ${Math.round(parseFloat(commitRatioSelect.value) * 100)}%+`);
+        }
 
         if (parts.length === 0) {
           statsElement.textContent = `Showing all ${sortedOrgs.length} organizations`;
@@ -154,7 +169,7 @@ document.fonts.ready.then(() => {
           statsElement.textContent = `Filtered by ${parts.join(", ")}`;
         }
 
-        const isFiltered = activeOrgs.length > 0 || starsSelect.value !== "" || forksSelect.value !== "";
+        const isFiltered = activeOrgs.length > 0 || starsSelect.value !== "" || forksSelect.value !== "" || commitRatioSelect.value !== "";
         filterToggle?.setAttribute("data-has-active-filters", String(isFiltered));
         document.getElementById("mobile-drawer")?.setAttribute("data-has-active-filters", String(isFiltered));
       }

--- a/src/state/filterState.ts
+++ b/src/state/filterState.ts
@@ -1,12 +1,13 @@
 import type { FilterState } from "../types";
 
-export type MetricKey = "starsMin" | "forksMin";
+export type MetricKey = "starsMin" | "forksMin" | "orgCommitRatioMin";
 
 export function createFilterState(): FilterState {
   return {
     organizations: [],
     starsMin: null,
     forksMin: null,
+    orgCommitRatioMin: null,
   };
 }
 
@@ -30,7 +31,7 @@ export function setMetricFilter(
   metric: MetricKey,
   value: number | null,
 ): FilterState {
-  if (metric === "starsMin" || metric === "forksMin") {
+  if (metric === "starsMin" || metric === "forksMin" || metric === "orgCommitRatioMin") {
     state[metric] = value;
   }
   return state;
@@ -40,6 +41,7 @@ export function clearFilters(state: FilterState): FilterState {
   state.organizations = [];
   state.starsMin = null;
   state.forksMin = null;
+  state.orgCommitRatioMin = null;
   return state;
 }
 
@@ -51,6 +53,7 @@ export function hasActiveFilters(state: FilterState): boolean {
   return (
     state.organizations.length > 0 ||
     state.starsMin !== null ||
-    state.forksMin !== null
+    state.forksMin !== null ||
+    state.orgCommitRatioMin !== null
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,7 @@ export interface FilterState {
   organizations: string[];
   starsMin: number | null;
   forksMin: number | null;
+  orgCommitRatioMin: number | null;
 }
 
 export interface DelaunayData {


### PR DESCRIPTION
Adds a new filter dropdown that shows only repos where at least X% of commits are from org contributors. Drafting the blog post I had the idea to show which that we are core maintainers for some really popular repos.

Thresholds: 25%, 50%, 75%, 90%.

- Uses existing orgCommits/totalCommits fields on RepoData. 
- Label is set dynamically from orgNickname config. 
- Follows the same cascade pattern as the existing stars/forks filters.

<img width="1437" height="722" alt="Screenshot 2026-04-08 at 10 33 49 PM" src="https://github.com/user-attachments/assets/a5a77f53-bc3e-4083-8fe8-dd441bf0f0ff" />
