### PR TITLE
Feat/package distribution

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,9 +42,9 @@ npm run dev
 ### Fetch Data & Build
 ```bash
 export GITHUB_TOKEN="your_token_here"
-uv run contributor-network data       # Fetch from GitHub
-uv run contributor-network csvs       # Generate CSVs
-uv run contributor-network build      # Build static site (runs Vite)
+uv run contributor-network fetch      # Fetch from GitHub
+uv run contributor-network build      # Generate CSVs and config.json
+npm run build                         # Build static site to dist/ (Vite)
 ```
 
 ---
@@ -54,9 +54,8 @@ uv run contributor-network build      # Build static site (runs Vite)
 ### Development
 ```bash
 # Run CLI commands
-uv run contributor-network data             # Fetch contribution data from GitHub
-uv run contributor-network csvs             # Generate CSVs from JSON
-uv run contributor-network build            # Build static site to dist/ (runs Vite)
+uv run contributor-network fetch            # Fetch contribution data from GitHub
+uv run contributor-network build            # Generate CSVs and config.json
 uv run contributor-network discover         # Find new repositories to track
 uv run contributor-network list-contributors # Display all configured contributors
 
@@ -256,9 +255,9 @@ Configured in `src/config/theme.ts`.
 
 ### Add a New Repository to Track
 1. Edit `config.toml` - add repo to `[repositories]` section
-2. Run `uv run contributor-network data` to fetch GitHub data
-3. Run `uv run contributor-network csvs` to generate CSVs
-4. Run `uv run contributor-network build` to rebuild site
+2. Run `uv run contributor-network fetch` to fetch GitHub data
+3. Run `uv run contributor-network build` to generate CSVs and `config.json`
+4. Run `npm run build` to rebuild the static site
 
 ### Add a New Contributor
 1. Edit `config.toml` - add to `[contributors.devseed]` or `[contributors.alumni]`

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -346,3 +346,29 @@ uv run pytest -v
 ---
 
 **Last Updated**: March 2026
+
+---
+
+## Releasing
+
+Both packages (`open-source-contributor-network` on PyPI, `@developmentseed/open-source-contributor-network` on npm) are published together on git tags matching `v*`.
+
+### One-time setup
+
+1. **PyPI trusted publishing** — at https://pypi.org/manage/account/publishing/ add a pending publisher:
+   - PyPI Project Name: `open-source-contributor-network`
+   - Owner: `developmentseed`
+   - Repository: `contributor-network`
+   - Workflow name: `release.yml`
+   - Environment name: `release`
+2. **npm token** — generate an automation token at https://www.npmjs.com/settings/<your-user>/tokens and add it as a repo Actions secret named `NPM_TOKEN`.
+3. **GitHub environment** — create a `release` environment in repo Settings → Environments. Optionally require manual approval.
+
+### Cutting a release
+
+1. Align the version in `pyproject.toml` and `package.json` to the target version (both must match).
+2. Commit the version bump.
+3. Tag and push: `git tag v1.2.3 && git push origin v1.2.3`.
+4. The `release.yml` workflow publishes both packages. If either job fails, fix and re-tag at the next version (`v1.2.4`) — republishing the same version is not allowed on either registry.
+
+Pre-release versions (e.g. `v0.1.0-rc1`) are supported for test runs.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
           git checkout -b build-data
           uv run contributor-network fetch
           uv run contributor-network build
+          npm run build
           git add .
           git commit -m "chore: update data"
           git push -u origin build-data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,7 @@ jobs:
         run: npm run typecheck
       - name: Test (TypeScript)
         run: npm test
-      - name: Build
+      - name: Generate data
         run: uv run contributor-network build
+      - name: Build frontend
+        run: npm run build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,10 +30,12 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "npm"
       - run: npm ci
-      - name: Build
+      - name: Generate data
         env:
           PLAUSIBLE_ID: ${{ vars.PLAUSIBLE_ID }}
         run: uv run contributor-network build
+      - name: Build frontend
+        run: npm run build
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "dist"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
 
   publish-npm:
     name: Publish to npm
+    needs: publish-pypi
     runs-on: ubuntu-latest
     environment: release
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ uv sync
 npm install
 ```
 
-If you've only made changes to the frontend, you can rebuild the site with:
+The build is split into two steps: `contributor-network build` generates the CSVs and `config.json` into `public/data/`, and `npm run build` runs Vite to produce the final static site in `dist/`.
 
 ```sh
-uv run contributor-network build
+uv run contributor-network build    # generate data
+npm run build                       # build the static site
 ```
 
 If you've changed the config and need to re-fetch data from the Github API, run this (warning, this takes a while):
@@ -66,10 +67,13 @@ uv run contributor-network discover --min-contributors 2
 # 4. Fetch data from GitHub
 uv run contributor-network fetch
 
-# 5. Build the site
+# 5. Generate data files
 uv run contributor-network build
 
-# 6. Preview locally
+# 6. Build the static site
+npm run build
+
+# 7. Preview locally
 npm run preview
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@developmentseed/open-source-contributor-network",
-  "version": "2.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@developmentseed/open-source-contributor-network",
-      "version": "2.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "d3": "^7.9.0",
         "d3-bboxCollide": "^1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "contributor-network-frontend",
+  "name": "@developmentseed/open-source-contributor-network",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "contributor-network-frontend",
+      "name": "@developmentseed/open-source-contributor-network",
       "version": "2.0.0",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@developmentseed/open-source-contributor-network",
-  "version": "2.0.0",
+  "version": "0.1.0",
   "description": "Frontend visualization for the Contributor Network",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "files": [
     "dist",
+    "!dist/data",
     "public/css",
     "public/img"
   ],

--- a/package.json
+++ b/package.json
@@ -1,8 +1,16 @@
 {
-  "name": "contributor-network-frontend",
+  "name": "@developmentseed/open-source-contributor-network",
   "version": "2.0.0",
   "description": "Frontend visualization for the Contributor Network",
   "type": "module",
+  "files": [
+    "dist",
+    "public/css",
+    "public/img"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "contributor-network"
+name = "open-source-contributor-network"
 version = "0.1.0"
 description = "A visualization of contributors to projects"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,36 @@ version = "0.1.0"
 description = "A visualization of contributors to projects"
 readme = "README.md"
 requires-python = ">=3.13"
+license = "MPL-2.0"
+license-files = ["LICENSE"]
+authors = [
+    { name = "Development Seed", email = "info@developmentseed.org" },
+]
+keywords = [
+    "github",
+    "contributors",
+    "visualization",
+    "d3",
+    "open-source",
+    "network",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Version Control :: Git",
+]
 dependencies = [
     "click>=8.2.1",
     "pydantic>=2.11.9",
     "pygithub>=2.8.1",
 ]
+
+[project.urls]
+Homepage = "https://developmentseed.org/contributor-network"
+Repository = "https://github.com/developmentseed/contributor-network"
 
 [project.scripts]
 contributor-network = "contributor_network.cli:main"

--- a/python/contributor_network/cli.py
+++ b/python/contributor_network/cli.py
@@ -1,6 +1,5 @@
 import json
 import os
-import subprocess
 from collections import defaultdict
 from csv import DictWriter
 from pathlib import Path
@@ -19,12 +18,6 @@ directory = click.option(
     type=click.Path(path_type=Path),
     default=ROOT / "public" / "data",
     help="The data directory",
-)
-destination = click.option(
-    "--destination",
-    type=click.Path(path_type=Path),
-    default=ROOT / "dist",
-    help="The destination for the HTML page assets",
 )
 config = click.option(
     "-c",
@@ -105,18 +98,17 @@ def fetch(
 @main.command()
 @directory
 @config
-@destination
 @all_contributors
-def build(
-    directory: Path, config_path: str | None, destination: Path, all_contributors: bool
-) -> None:
-    """Build the HTML site."""
+def build(directory: Path, config_path: str | None, all_contributors: bool) -> None:
+    """Generate CSVs and config.json for the contributor network site."""
     config = Config.from_toml(config_path or DEFAULT_CONFIG_PATH)
     contributors = (
         config.all_contributors if all_contributors else config.core_contributors
     )
     authors = list(contributors.values())
     print(f"Writing CSVs for {len(authors)} contributors")
+
+    directory.mkdir(parents=True, exist_ok=True)
 
     (directory / "top_contributors.csv").write_text(
         "\n".join(["author_name"] + authors)
@@ -142,9 +134,6 @@ def build(
         writer.writeheader()
         writer.writerows(links)
 
-    data_dest = directory
-    data_dest.mkdir(parents=True, exist_ok=True)
-
     config_json = {
         "title": config.title,
         "description": config.description,
@@ -159,14 +148,10 @@ def build(
         },
         "plausible_id": os.environ.get("PLAUSIBLE_ID", ""),
     }
-    (data_dest / "config.json").write_text(
+    (directory / "config.json").write_text(
         json.dumps(config_json, indent=2, ensure_ascii=False)
     )
-    print(f"Generated config.json in {data_dest}")
-
-    print("Running Vite build...")
-    subprocess.run(["npm", "run", "build"], cwd=ROOT, check=True)
-    print(f"Vite build complete, output in {destination}")
+    print(f"Generated config.json in {directory}")
 
 
 @main.command()

--- a/python/tests/test_cli_build.py
+++ b/python/tests/test_cli_build.py
@@ -1,0 +1,50 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from contributor_network.cli import main
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "data"
+    (d / "repositories").mkdir(parents=True)
+    (d / "links").mkdir(parents=True)
+    return d
+
+
+@pytest.fixture
+def config_path(tmp_path: Path) -> Path:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        'title = "Test Network"\n'
+        'description = "Test description"\n'
+        'organization_name = "Test Org"\n'
+        "repositories = []\n"
+        "\n"
+        "[contributors.core]\n"
+        'alice = "Alice"\n'
+    )
+    return path
+
+
+def test_build_generates_data_files_without_invoking_npm(
+    data_dir: Path, config_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_if_called(*args: object, **kwargs: object) -> None:
+        pytest.fail(f"subprocess.run should not be called, got args={args}")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["build", "--directory", str(data_dir), "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (data_dir / "top_contributors.csv").exists()
+    assert (data_dir / "repositories.csv").exists()
+    assert (data_dir / "links.csv").exists()
+    assert (data_dir / "config.json").exists()

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,4 +138,4 @@ export type {
   PreparedData,
 } from "./types";
 
-export const VERSION = "2.0.0";
+export const VERSION = "0.1.0";

--- a/uv.lock
+++ b/uv.lock
@@ -123,37 +123,6 @@ wheels = [
 ]
 
 [[package]]
-name = "contributor-network"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "click" },
-    { name = "pydantic" },
-    { name = "pygithub" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "click", specifier = ">=8.2.1" },
-    { name = "pydantic", specifier = ">=2.11.9" },
-    { name = "pygithub", specifier = ">=2.8.1" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy", specifier = ">=1.18.1" },
-    { name = "pytest", specifier = ">=8.4.2" },
-    { name = "ruff", specifier = ">=0.13.0" },
-]
-
-[[package]]
 name = "cryptography"
 version = "45.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -239,6 +208,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "open-source-contributor-network"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "pydantic" },
+    { name = "pygithub" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.2.1" },
+    { name = "pydantic", specifier = ">=2.11.9" },
+    { name = "pygithub", specifier = ">=2.8.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.18.1" },
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "ruff", specifier = ">=0.13.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
### NPM module and PyPi publication

Makes the previous `uv run contributor-network build` step data only and adds `npm run build` to build the frontend. 
Allows the Python package to ship on PyPI without requiring npm/Node on consumer machines.

Some smaller changes as a result:
- Remove subprocess call from Python `build` command
- Rename package to `open-source-contributor-network` (PyPI-unique name)
- Drop unused jinja2 dependency
- Update CI workflows to run both steps separately
- Add test guarding the decoupling
- Enrich PyPI metadata (license, authors, keywords, classifiers)

For specific attention during review:
- [ ] Is this what you had in mind with https://github.com/developmentseed/contributor-network/issues/124 ?
- [ ] Metadata for PyPi publication, would you change anything?
- [ ] Confirming no visual changes to the app (I tested and didn't see anything broken)
- [ ] Do you think we should also change the name of the old `uv run contributor-network build` step to differentiate from `npm run build` or is the similarity acceptable?