### PR TITLE
feat: make build output paths cwd-relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The following `config.toml` fields populate `<meta>` tags in `index.html` at bui
 
 `index.html` is rendered from [`python/contributor_network/templates/index.html.j2`](./python/contributor_network/templates/index.html.j2) by `contributor-network build` and is gitignored. To change page structure, edit the template (not the generated file). Forks can override the meta-tag values without modifying the template.
 
-By default `contributor-network build` writes `index.html` and `public/data/` relative to the current working directory; pass `--html-output <path>` and `--directory <path>` to override. This lets downstream consumers (e.g. site forks) install the package and run the build from any working tree.
+`contributor-network build` writes `index.html` and `public/data/` relative to the current working directory (pass `--directory <path>` to relocate the data files). This lets downstream consumers (e.g. site forks) install the package and run the build from any working tree.
 
 ## Branding
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ The following `config.toml` fields populate `<meta>` tags in `index.html` at bui
 
 `index.html` is rendered from [`python/contributor_network/templates/index.html.j2`](./python/contributor_network/templates/index.html.j2) by `contributor-network build` and is gitignored. To change page structure, edit the template (not the generated file). Forks can override the meta-tag values without modifying the template.
 
+By default `contributor-network build` writes `index.html` and `public/data/` relative to the current working directory; pass `--html-output <path>` and `--directory <path>` to override. This lets downstream consumers (e.g. site forks) install the package and run the build from any working tree.
+
 ## Branding
 
 This visualization uses the Development Seed brand colors:

--- a/python/contributor_network/cli.py
+++ b/python/contributor_network/cli.py
@@ -32,13 +32,18 @@ def render_index_html(config: Config) -> str:
     )
 
 
-ROOT = Path(__file__).absolute().parents[2]
 DEFAULT_CONFIG_PATH = "config.toml"
 directory = click.option(
     "--directory",
     type=click.Path(path_type=Path),
-    default=ROOT / "public" / "data",
-    help="The data directory",
+    default=Path("public") / "data",
+    help="The data directory (relative paths are resolved against the current working directory)",
+)
+html_output = click.option(
+    "--html-output",
+    type=click.Path(path_type=Path),
+    default=Path("index.html"),
+    help="Where to write the rendered index.html (relative paths are resolved against the current working directory)",
 )
 config = click.option(
     "-c",
@@ -118,9 +123,15 @@ def fetch(
 
 @main.command()
 @directory
+@html_output
 @config
 @all_contributors
-def build(directory: Path, config_path: str | None, all_contributors: bool) -> None:
+def build(
+    directory: Path,
+    html_output: Path,
+    config_path: str | None,
+    all_contributors: bool,
+) -> None:
     """Generate CSVs and config.json for the contributor network site."""
     config = Config.from_toml(config_path or DEFAULT_CONFIG_PATH)
     contributors = (
@@ -174,8 +185,9 @@ def build(directory: Path, config_path: str | None, all_contributors: bool) -> N
     )
     print(f"Generated config.json in {directory}")
 
-    (ROOT / "index.html").write_text(render_index_html(config))
-    print(f"Generated index.html at {ROOT / 'index.html'}")
+    html_output.parent.mkdir(parents=True, exist_ok=True)
+    html_output.write_text(render_index_html(config))
+    print(f"Generated index.html at {html_output}")
 
 
 @main.command()

--- a/python/contributor_network/cli.py
+++ b/python/contributor_network/cli.py
@@ -39,12 +39,6 @@ directory = click.option(
     default=Path("public") / "data",
     help="The data directory (resolved against cwd if relative)",
 )
-html_output = click.option(
-    "--html-output",
-    type=click.Path(path_type=Path),
-    default=Path("index.html"),
-    help="Where to write the rendered index.html (resolved against cwd if relative)",
-)
 config = click.option(
     "-c",
     "--config",
@@ -123,15 +117,9 @@ def fetch(
 
 @main.command()
 @directory
-@html_output
 @config
 @all_contributors
-def build(
-    directory: Path,
-    html_output: Path,
-    config_path: str | None,
-    all_contributors: bool,
-) -> None:
+def build(directory: Path, config_path: str | None, all_contributors: bool) -> None:
     """Generate CSVs and config.json for the contributor network site."""
     config = Config.from_toml(config_path or DEFAULT_CONFIG_PATH)
     contributors = (
@@ -185,9 +173,9 @@ def build(
     )
     print(f"Generated config.json in {directory}")
 
-    html_output.parent.mkdir(parents=True, exist_ok=True)
-    html_output.write_text(render_index_html(config))
-    print(f"Generated index.html at {html_output}")
+    index_html = Path("index.html")
+    index_html.write_text(render_index_html(config))
+    print(f"Generated index.html at {index_html}")
 
 
 @main.command()

--- a/python/contributor_network/cli.py
+++ b/python/contributor_network/cli.py
@@ -37,13 +37,13 @@ directory = click.option(
     "--directory",
     type=click.Path(path_type=Path),
     default=Path("public") / "data",
-    help="The data directory (relative paths are resolved against the current working directory)",
+    help="The data directory (resolved against cwd if relative)",
 )
 html_output = click.option(
     "--html-output",
     type=click.Path(path_type=Path),
     default=Path("index.html"),
-    help="Where to write the rendered index.html (relative paths are resolved against the current working directory)",
+    help="Where to write the rendered index.html (resolved against cwd if relative)",
 )
 config = click.option(
     "-c",


### PR DESCRIPTION
## Summary

Removes the `__file__`-derived `ROOT` constant from the `build` command so output paths are no longer pinned to where the package is installed.

- `--directory` now defaults to `public/data` (cwd-relative)
- New `--html-output` flag, defaults to `index.html` (cwd-relative)

Upstream behavior is unchanged when run from the repo root.

## Why

When upstream is installed as a Python package by a downstream fork (e.g. \`nasa-odsi-contributor-network\`), \`__file__\` resolves inside the consumer's \`.venv/\`, so \`ROOT / "index.html"\` lands in a useless venv-internal path. With cwd-relative defaults, downstream forks can install the CLI and run \`contributor-network build\` from any directory — the rendered \`index.html\` lands where the consumer's \`cwd\` is, alongside their overlaid \`config.toml\` and \`public/\`.

This unblocks the [nasa-odsi-contributor-network upstream-reuse cutover](https://github.com/developmentseed/nasa-odsi-contributor-network), which uses \`degit\` to copy upstream's frontend into a cache directory and runs \`build\` from there.

## Test plan

- [x] Existing tests pass (\`uv run pytest\` — 3/3)
- [x] Running \`uv run contributor-network build\` from the upstream repo root still writes \`index.html\` to repo root (verified manually; output unchanged)
- [x] Running the build from a different cwd writes \`index.html\` and \`public/data/\` relative to that cwd (verified manually with \`/tmp/build-from-elsewhere\`)